### PR TITLE
fix bug

### DIFF
--- a/src/main/java/com/best/hello/controller/SSTI.java
+++ b/src/main/java/com/best/hello/controller/SSTI.java
@@ -149,6 +149,11 @@ public class SSTI {
             log.error("关闭流失败", e);
         }
 
+        if (request.getRequestURI().contains("/freemarker/vul")) {
+            // 如果访问的 URI 路径包含 /freemarker/vul 则使用不安全的解析器
+            conf.setNewBuiltinClassResolver(TemplateClassResolver.UNRESTRICTED_RESOLVER);
+        }
+
         // 添加模板到 StringTemplateLoader，并禁用缓存和异常日志
         stringTemplateLoader.putTemplate(file, content);
         conf.setTemplateUpdateDelayMilliseconds(0);


### PR DESCRIPTION
修复了点击 Freemark安全代码之后原来的 Freemark 漏洞代码被修复的问题（原因是使用了同一个conf，如不解决的话需要重启项目Freemark漏洞代码才可继续生效。）